### PR TITLE
Added note to README.md (Ubuntu/Debian apt command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The KCM is only build, if the -DNO_SYSTEMD option is unset or set to false.
 ## Debian/Ubuntu command to install the build requirements:
 `sudo apt-get install libkf5config-dev libkf5auth-dev libkf5package-dev libkf5declarative-dev libkf5coreaddons-dev libkf5kcmutils-dev libkf5i18n-dev libqt5core5a libqt5widgets5 libqt5gui5 libqt5qml5 extra-cmake-modules qtbase5-dev`
 
+**Note:** This was tested on Linux Mint 18.2 KDE, which is based on Ubuntu 16.04 LTS (Debian 9 Stretch/Sid).
 
 ## Example:
 


### PR DESCRIPTION
This adds a note wherein it states that the apt-get install command for the build was initially tested on Linux Mint 18.2 KDE, which is based on Ubuntu 16.04 LTS (Debian 9 Stretch/Sid). This is intended to provide greater transparency for what specific Ubuntu/Debian environment was this proven to work on. This info may become useful for those running either older or newer releases since there may be slight differences in the package names for those versions.

This should (hopefully) help prevent confusion from users and devs compiling the software on other Ubuntu/Debian environments from asking questions like "*Why doesn't this command work*?", "*These packages don't exist, what do I do now?*", and etcetera.