### PR TITLE
Update build dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ To compile the additional KDE Plasma plasmoid set the cmake option -DBUILD_PLASM
 ## Commands to install requirements
 ### Debian/Ubuntu command to install the build requirements:
 ```
-sudo apt-get install libkf5config-dev libkf5auth-dev libkf5package-dev libkf5declarative-dev libkf5coreaddons-dev libkf5dbusaddons-dev libkf5kcmutils-dev libkf5i18n-dev libkf5plasma-dev libqt5core5a libqt5widgets5 libqt5gui5 libqt5qml5 extra-cmake-modules qtbase5-dev libkf5notifications-dev qml-module-org-kde-kirigami2 qml-module-qtquick-dialogs qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel cmake build-essential gettext
+sudo apt-get install ca-certificates git build-essential cmake gcc g++ libkf5config-dev libkf5auth-dev libkf5package-dev libkf5declarative-dev libkf5coreaddons-dev libkf5dbusaddons-dev libkf5kcmutils-dev libkf5i18n-dev libkf5plasma-dev libqt5core5a libqt5widgets5 libqt5gui5 libqt5qml5 extra-cmake-modules qtbase5-dev libkf5notifications-dev qml-module-org-kde-kirigami2 qml-module-qtquick-dialogs qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel cmake build-essential gettext
 ```
-**Note:** This was tested on KDE Neon User Edition 5.14, which is based on Ubuntu 18.04 LTS (Debian 9 Stretch/Sid).
+**Note:** This was tested on `Ubuntu 20.04.1 LTS` and `Debian 10`.
 
 ### Fedora:
 ```
-sudo dnf install qt5-devel kf5-ki18n-devel kf5-kauth-devel kf5-kconfig-devel kf5-kpackage-devel kf5-kcoreaddons-devel kf5-kdbusaddons-devel extra-cmake-modules kf5-knotifications-devel qt5-qtquickcontrols2-devel kf5-kconfigwidgets-devel kf5-kcmutils-devel kf5-plasma-devel cmake gettext qt5-qtbase-devel gcc-c++ kf5-kdeclarative-devel qt5-qtquickcontrols qt5-qtquickcontrols2
+sudo dnf install git gcc g++ cmake kf5-ki18n-devel kf5-kauth-devel kf5-kconfig-devel kf5-kpackage-devel kf5-kcoreaddons-devel kf5-kdbusaddons-devel extra-cmake-modules kf5-knotifications-devel qt5-qtquickcontrols2-devel kf5-kconfigwidgets-devel kf5-kcmutils-devel kf5-plasma-devel cmake gettext qt5-qtbase-devel gcc-c++ kf5-kdeclarative-devel qt5-qtquickcontrols qt5-qtquickcontrols2
 ```
-**Note:** This was tested on Fedora 31.
+**Note:** This was tested on `Fedora 33`.
 
 # Install:
 


### PR DESCRIPTION
Updated build dependencies for Ubuntu 20.04.1, Debian 10, and Fedora 33. Each was tested individually via docker and all were able to successfully compile it.

Added transient dependencies explicitly rather than assuming that the build host will have them installed (eg. git, gcc, g++, cmake, ca-certificates, and build-essentials).